### PR TITLE
Avoid repeated predicates in PDDL domain generation

### DIFF
--- a/packages/@unitn-asa/pddl-client/src/PddlDomain.js
+++ b/packages/@unitn-asa/pddl-client/src/PddlDomain.js
@@ -23,12 +23,16 @@ export default class PddlDomain {
         this.addAction(...actions)
         
     }
-    
+
     addPredicate (predicate) { // predicate = 'light-on ?l'
         if ( this.predicates.find( (e) => e == predicate ) )
             return false;
-        if ( this.predicates.find( (e) => e.split(' ')[0] == predicate.split(' ')[0] && e.split(' ').length != predicate.split(' ').length ) )
+        if ( this.predicates.find( (e) => e.split(' ')[0] === predicate.split(' ')[0] && e.split(' ').length !== predicate.split(' ').length ) )
             throw new Error( 'Duplicated predicate with different number of parameters!' )
+
+        if ( this.predicates.find( (e) => e.split(' ')[0] === predicate.split(' ')[0] && e.split(' ').length === predicate.split(' ').length ) )
+            return false;
+            
         this.predicates.push(predicate)
         return true;
     }


### PR DESCRIPTION
As already addressed in #1:

https://github.com/unitn-ASA/Deliveroo.js/blob/df18cdf00e2bccd69be5b327545b64db96b736b3/packages/%40unitn-asa/pddl-client/src/PddlDomain.js#L32

Even after the fix has been implemented, if I am not wrong, this operation should be performed only a single time for each predicate with the same name. Therefore, if we find both `(light ?l) (light ?m) (light ?l-with-different-len)`, the push action should be executed only when processing the first predicate occurence.

Please, consider the fact that to run my project, (developed alongside with my teammate @fedeizzo), the fix in this Pull Request is required