### PR TITLE
fix(ioServer): send current frame in ping for client clock sync

### DIFF
--- a/backend/src/ioServer.js
+++ b/backend/src/ioServer.js
@@ -201,8 +201,11 @@ class ioServer {
                         timestampAtPing = performance.now();
                         frameAtPing = myClock.frame;
 
-                        // Send ping with previous latency data (or null on first ping)
-                        socket.emit('ping', {frame: lastLatencyData.frame, roundTrip: lastLatencyData.roundTrip}, () => { // acknoledgment callback
+                        // Send the CURRENT frame for clock sync (frameAtPing), paired with the
+                        // previous round-trip (this ping's RTT is unknown until its pong returns).
+                        // Sending lastLatencyData.frame here lagged the clock anchor by a full ping
+                        // cycle (~PING_INTERVAL/CLOCK ticks) + RTT, skewing client tick interpolation.
+                        socket.emit('ping', {frame: frameAtPing, roundTrip: lastLatencyData.roundTrip}, () => { // acknoledgment callback
                             
                             // when pong is received
                             try {


### PR DESCRIPTION
The ping payload emitted lastLatencyData.frame, the frame captured at the previous pong, so it lagged the true frame by ~PING_INTERVAL/CLOCK ticks plus round-trip. Clients anchor their interpolated tick to this frame (anchorFrame = data.frame at receive-time), so the lag skewed every client's tick, and by a different amount per client (independent ping phase + RTT), breaking cross-agent tick comparison.

Emit frameAtPing (the frame at emit time) instead. roundTrip stays the previous measurement, which is correct: this ping's RTT is unknown until its pong returns. The latency monitor reads lastLatencyData and is unaffected.